### PR TITLE
Fix dash typo in consumer systemd service file

### DIFF
--- a/init/ams-consumer.service
+++ b/init/ams-consumer.service
@@ -8,4 +8,4 @@ ExecStart=/usr/bin/ams-consumerd -d start -c /etc/argo-ams-consumer/ams-consumer
 ExecStop=/usr/bin/ams-consumerd -d stop -c /etc/argo-ams-consumer/ams-consumer.conf 
 
 [Install]
-WantedBy=multi−user.target
+WantedBy=multi-user.target


### PR DESCRIPTION
Fix typo in WantedBy parameter having a `Minus Sign` Unicode character `U+2212` instead of a simple hyphen