### PR TITLE
ARGO-2080 Refactor AMS clients to use retry ams-library feature

### DIFF
--- a/bin/ams-consumerd
+++ b/bin/ams-consumerd
@@ -54,6 +54,7 @@ def doMainProgram():
         try:
             for id, msg in ams.pull_sub(subscriptions, msg_num,
                                         retry=pull_nretry,
+                                        return_immediately=True,
                                         retrysleep=pull_retrysleep,
                                         timeout=timeout):
                 ackIds.append(id)


### PR DESCRIPTION
* this one enables `return_immediately` as it was before